### PR TITLE
See Pandoc issue 7847

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
 pdf: *.md
 	mkdir -p build
-	pandoc --toc \
+	pandoc 			 --toc \
+				 --columns=300 \
 				 -s \
 				 --template=pdf/template.tex \
 				 -V title="Madison Area Jugglers' Pattern Book" \


### PR DESCRIPTION
https://github.com/jgm/pandoc/issues/7847

Pandoc developers recently made changes to how tables are rendered.  The change seems to have introduced a bug/feature where if the number of characters in a table row exceeds the --columns flag value (default 72), then a compilation error is thrown.  

The work around (for now) is to set the --columns flag to a larger value.  This fixes the build and, from the handful of tables  I have looked at in the pdf result, doesn't appear to mess up any tables.  Though I have not looked at all tables.